### PR TITLE
リフト修正と挟まれる処理

### DIFF
--- a/MagnetGame/Project1/Source/Actor/Magnet/Magnet.cpp
+++ b/MagnetGame/Project1/Source/Actor/Magnet/Magnet.cpp
@@ -17,7 +17,8 @@ Magnet::Magnet(IGameMediator * pGameMediator, MagnetOption magOption, bool isMov
 	: GameObject(pGameMediator),
 	m_MagOption(magOption),
 	m_IsMove(isMove),
-	m_IsMagChange(isMagChange)
+	m_IsMagChange(isMagChange),
+	m_PrePosition(getPosition())
 {
 	setSize(Vec3(width, height, 0));
 }
@@ -69,9 +70,11 @@ void Magnet::update()
 	readMagMap();
 	if (m_pRider != nullptr)
 	{
-		Vec3 vel = Vec3(m_Velocity.x, MathUtility::clamp(m_Velocity.y, -128.0f, 0), 0);
-		m_pRider->setPosition(m_pRider->getPosition() + vel);
+		Vec3 vel = getPosition() - m_PrePosition;
+		Vec3 move = Vec3(vel.x, MathUtility::clamp(m_Velocity.y, -128.0f, 0), 0);
+		m_pRider->setPosition(m_pRider->getPosition() + move);
 	}
+	m_PrePosition = getPosition();
 }
 
 void Magnet::onCollisionEnter(GameObject * pHit)

--- a/MagnetGame/Project1/Source/Actor/Magnet/Magnet.h
+++ b/MagnetGame/Project1/Source/Actor/Magnet/Magnet.h
@@ -55,6 +55,8 @@ private:
 
 	static const float MAG_MOVE_SPEED;
 	Vec2 m_Velocity;
+	Vec3 m_PrePosition;
+	Vec2 m_Movement;
 
 	Vec2 m_PreNForce;
 	Vec2 m_PreSForce;

--- a/MagnetGame/Project1/Source/Actor/Player/Player.cpp
+++ b/MagnetGame/Project1/Source/Actor/Player/Player.cpp
@@ -67,6 +67,7 @@ void Player::update()
 	m_pDetectDown->setPosition(pos + Vec3(0, -1.1f, 0) * distY);
 	m_pDetectRight->setPosition(pos + Vec3(1, 0, 0) * distX);
 	m_pDetectLeft->setPosition(pos + Vec3(-1, 0, 0) * distX);
+	m_pDetectMid->setPosition(pos + Vec3(0, 0, 0));
 
 	if (GameInput::getHorizontal() < 0)
 		isFlipX = true;
@@ -78,8 +79,8 @@ void Player::update()
 
 	setMagChange();
 
-	//if (isSandwich())
-	//	destroy();
+	if (isSandwich())
+		Respawn();
 }
 
 void Player::onDestroy()
@@ -90,6 +91,7 @@ void Player::onDestroy()
 	m_pDetectDown->destroy();
 	m_pDetectRight->destroy();
 	m_pDetectLeft->destroy();
+	m_pDetectMid->destroy();
 }
 
 Gravity * Player::getGravity()
@@ -129,8 +131,7 @@ bool Player::canSuperJump()
 
 bool Player::isSandwich()
 {
-	return (m_pDetectRight->isDetect("Block") || m_pDetectRight->isDetect("MagnetN") || m_pDetectRight->isDetect("MagnetS")) &&
-		(m_pDetectLeft->isDetect("Block") || m_pDetectLeft->isDetect("MagnetN") || m_pDetectLeft->isDetect("MagnetS"));
+	return m_pDetectMid->isDetect();
 }
 
 void Player::Respawn()
@@ -200,6 +201,9 @@ void Player::initDetectors()
 
 	m_pDetectLeft = new DetectHelper(m_pGameMediator, this, { "Block", "MagnetN", "MagnetS" });
 	m_pDetectLeft->setSize(Vec3(6, sizeX, 0));
+
+	m_pDetectMid = new DetectHelper(m_pGameMediator, this, { "Block", "MagnetN", "MagnetS" });
+	m_pDetectMid->setSize(Vec3(16, 16, 0));
 }
 
 void Player::initAnimations()

--- a/MagnetGame/Project1/Source/Actor/Player/Player.h
+++ b/MagnetGame/Project1/Source/Actor/Player/Player.h
@@ -56,6 +56,7 @@ private:
 	DetectHelper* m_pDetectDown;
 	DetectHelper* m_pDetectRight;
 	DetectHelper* m_pDetectLeft;
+	DetectHelper* m_pDetectMid;
 
 	AnimSpriteRenderer* m_pAnimRenderer;
 


### PR DESCRIPTION
・マグネットに乗った時、マグネットが動いてないときでもプレイヤーが動いてしまうバグを修正
・プレイヤーが挟まれるのを検知する処理を追加(とりあえず挟まれたらリスポーン)